### PR TITLE
addressessコントローラの修正

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -2,6 +2,6 @@ class AddressesController < ApplicationController
 
   def new
     @user = User.find(params[:user_id])
-    @address = Address.find_by(id: (params[:user_id]))
+    @address = Address.new
   end
 end


### PR DESCRIPTION
# what
アドレスコントローラのnewアクションで、特定の住所を引き出す実装になっているため、newに変更する。

# why
この時点でaddressテーブルにフィールドが追加されていない場合もあるため。