### PR TITLE
出品者と購入者カラムをitemsテーブルに追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,9 +7,8 @@ class Item < ApplicationRecord
   belongs_to :user
   belongs_to :category
   belongs_to :delivery
+  belongs_to :buyer, class_name: "User"
 
-  has_one :purchase
-  accepts_nested_attributes_for :purchase
 
   scope :category1, -> { where(category_id: 1) }
   scope :category2, -> { where(category_id: 2) }

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,4 +1,0 @@
-class Purchase < ApplicationRecord
-  belongs_to :user
-  belongs_to :item
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,10 @@ class User < ApplicationRecord
   has_many :items
   has_many :comments
   has_many :evaluations
-  has_many :purchases
   has_many :item_likes
+  has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
+  has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "user_id", class_name: "Item"
+  has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "user_id", class_name: "Item"
 
   has_one :address
   has_one :creditcard

--- a/db/migrate/20190912044459_create_purchases.rb
+++ b/db/migrate/20190912044459_create_purchases.rb
@@ -1,9 +1,0 @@
-class CreatePurchases < ActiveRecord::Migration[5.2]
-  def change
-    create_table :purchases do |t|
-      t.integer    :status, null: false
-      t.references :user,   null: false,  foreign_key: true
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20190925055015_remove_user_id_from_purchases.rb
+++ b/db/migrate/20190925055015_remove_user_id_from_purchases.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromPurchases < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :purchases, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20190925055247_add_user_ref_to_purchase.rb
+++ b/db/migrate/20190925055247_add_user_ref_to_purchase.rb
@@ -1,0 +1,5 @@
+class AddUserRefToPurchase < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :purchases, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20190925060152_change_data_status_to_purchase.rb
+++ b/db/migrate/20190925060152_change_data_status_to_purchase.rb
@@ -1,0 +1,5 @@
+class ChangeDataStatusToPurchase < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :purchases, :status, :string
+  end
+end

--- a/db/migrate/20190925063036_remove_user_from_purchases.rb
+++ b/db/migrate/20190925063036_remove_user_from_purchases.rb
@@ -1,0 +1,5 @@
+class RemoveUserFromPurchases < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :purchases, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20190926014815_destory_purchases_table.rb
+++ b/db/migrate/20190926014815_destory_purchases_table.rb
@@ -1,0 +1,5 @@
+class DestoryPurchasesTable < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :purchases
+  end
+end

--- a/db/migrate/20190926015457_add_columns_to_items.rb
+++ b/db/migrate/20190926015457_add_columns_to_items.rb
@@ -1,0 +1,6 @@
+class AddColumnsToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :saler_id, :integer
+    add_column :items, :buyer_id, :integer
+  end
+end

--- a/db/migrate/20190926024852_remove_saler_id_from_items.rb
+++ b/db/migrate/20190926024852_remove_saler_id_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveSalerIdFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :saler_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_24_114908) do
+ActiveRecord::Schema.define(version: 2019_09_26_024852) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "postcode"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2019_09_24_114908) do
     t.string "brand"
     t.integer "size"
     t.bigint "delivery_id"
+    t.integer "buyer_id"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["delivery_id"], name: "index_items_on_delivery_id"
     t.index ["user_id"], name: "index_items_on_user_id"
@@ -96,16 +97,6 @@ ActiveRecord::Schema.define(version: 2019_09_24_114908) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_pictures_on_item_id"
-  end
-
-  create_table "purchases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "status", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "item_id", null: false
-    t.index ["item_id"], name: "index_purchases_on_item_id"
-    t.index ["user_id"], name: "index_purchases_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -139,8 +130,6 @@ ActiveRecord::Schema.define(version: 2019_09_24_114908) do
   add_foreign_key "items", "deliveries"
   add_foreign_key "items", "users"
   add_foreign_key "pictures", "items"
-  add_foreign_key "purchases", "items"
-  add_foreign_key "purchases", "users"
   add_foreign_key "users", "addresses"
   add_foreign_key "users", "creditcards"
 end


### PR DESCRIPTION
# what
purchasesテーブルを削除し、
出品者と購入者カラムをitemsテーブルに追加した。

# why
出品者と購入者のカラムを追加し、以下3点をuserモデルのアソシエーションを組むことで、
purchasesテーブルで管理する予定だった「出品中」「購入済」ステータスを別で管理するため。

buyed_items
saling_items
sold_items
