### PR TITLE
SNS認証のキーをcredentials.ymlに設定

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,11 +267,8 @@ Devise.setup do |config|
   # config.omniauth :facebook,
   #                 Rails.application.secrets.facebook_client_id,
   #                 Rails.application.secrets.facebook_client_secret
-
-  # config.omniauth :facebook,ENV['FACEBOOK_APP_ID'],ENV['FACEBOOK_APP_SECRET']
-  # config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
-  config.omniauth :facebook, Rails.application.credentials.omniauth[:FACEBOOK_APP_ID], Rails.application.credentials.omniauth[:FACEBOOK_APP_SECRET], display: 'popup'
-  config.omniauth :google_oauth2, Rails.application.credentials.omniauth[:GOOGLE_CLIENT_ID], Rails.application.credentials.omniauth[:GOOGLE_CLIENT_SECRET], display: 'popup'
+  config.omniauth :facebook, Rails.application.credentials.omniauth[:FACEBOOK_APP_ID], Rails.application.credentials.omniauth[:FACEBOOK_APP_SECRET]
+  config.omniauth :google_oauth2, Rails.application.credentials.omniauth[:GOOGLE_CLIENT_ID], Rails.application.credentials.omniauth[:GOOGLE_CLIENT_SECRET]
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -268,9 +268,10 @@ Devise.setup do |config|
   #                 Rails.application.secrets.facebook_client_id,
   #                 Rails.application.secrets.facebook_client_secret
 
-  config.omniauth :facebook,ENV['FACEBOOK_APP_ID'],ENV['FACEBOOK_APP_SECRET']
-  config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
-
+  # config.omniauth :facebook,ENV['FACEBOOK_APP_ID'],ENV['FACEBOOK_APP_SECRET']
+  # config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
+  config.omniauth :facebook, Rails.application.credentials.omniauth[:FACEBOOK_APP_ID], Rails.application.credentials.omniauth[:FACEBOOK_APP_SECRET], display: 'popup'
+  config.omniauth :google_oauth2, Rails.application.credentials.omniauth[:GOOGLE_CLIENT_ID], Rails.application.credentials.omniauth[:GOOGLE_CLIENT_SECRET], display: 'popup'
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.


### PR DESCRIPTION
# What
SNS認証のキーをcredentials.ymlに設定

# Why
envファイルにキーを置いていたがチームで共有できるようにcredentials.ymlに設定し直しました