### PR TITLE
出品した商品ページにパンくずを追加

### DIFF
--- a/app/views/users/exhibit_list.html.haml
+++ b/app/views/users/exhibit_list.html.haml
@@ -1,3 +1,6 @@
+
+- breadcrumb :exhibited
+= render 'shared/breadcrumbs'
 %main.main__contents
   .main__contents__contents
     = render 'shared/exhibit-now'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -6,18 +6,23 @@ end
 crumb :mypage do
   link "マイページ", user_path
 end
-# メルカリ＞マイページ＞プロフィール
+# メルカリ > マイページ > プロフィール
 crumb :profile do|profile|
   link 'プロフィール'
   parent :mypage
 end
-# メルカリ＞マイページ＞本人情報の登録
+# メルカリ > マイページ > 本人情報の登録
 crumb :information do|information|
   link '本人情報の登録'
   parent :mypage
 end
-# メルカリ＞マイページ＞ログアウト
+# メルカリ > マイページ > ログアウト
 crumb :logout do|logout|
   link 'ログアウト'
+  parent :mypage
+end
+# メルカリ > マイページ > 出品した商品 - 出品中
+crumb :exhibited do|exhibited|
+  link '出品した商品 - 出品中'
   parent :mypage
 end


### PR DESCRIPTION
# What
出品した商品ページにパンくずを追加

# Why
ユーザーに今どの階層のページにいるのかを分かりやすくするため
